### PR TITLE
refactor: standardize error output using GLib's printerr

### DIFF
--- a/src/pdf2svg.vala
+++ b/src/pdf2svg.vala
@@ -27,7 +27,6 @@ public class PdfSvgConv.Pdf2Svg {
     static string? page_label = null;
 
     const OptionEntry[] options = {
-        { "help", 'h', OptionFlags.NONE, OptionArg.NONE, ref show_help, "Show help message", null },
         { "version", 'v', OptionFlags.NONE, OptionArg.NONE, ref show_version, "Display version", null },
         { "color", '\0', OptionFlags.NONE, OptionArg.INT, ref color_level, "Color level of log, 0 for no color, 1 for auto, 2 for always; defaults to 1", "LEVEL" },
         { "threads", 'T', OptionFlags.NONE, OptionArg.INT, ref num_threads, "Number of threads to use, 0 for auto; defaults to 0", "NUM" },
@@ -38,10 +37,7 @@ public class PdfSvgConv.Pdf2Svg {
 
     // Main program function
     static int main (string[] original_args) {
-        // Compatibility for Windows and Unix
-        if (Intl.setlocale (LocaleCategory.ALL, ".UTF-8") == null) {
-            Intl.setlocale ();
-        }
+        Intl.setlocale ();
 
 #if WINDOWS
         var args = Win32.get_command_line ();
@@ -52,7 +48,6 @@ public class PdfSvgConv.Pdf2Svg {
         // DO NOT use the default help option provided by g_print
         // g_print will force to convert character set to windows's code page
         // which is imcompatible windows's bash, zsh, etc.
-        opt_context.set_help_enabled (false);
         opt_context.add_main_entries (options, null);
         // Set a summary hint for multi-page output:
         opt_context.set_summary (
@@ -64,7 +59,7 @@ Hint: For multi-page conversion, use a format string like 'output-%04d.svg'."
             opt_context.parse_strv (ref args);
         } catch (OptionError e) {
             Reporter.error_puts ("OptionError", e.message);
-            stderr.printf ("\n%s", opt_context.get_help (true, null));
+            printerr ("\n%s", opt_context.get_help (true, null));
             return 1; // Argument parsing error
         }
 
@@ -84,11 +79,6 @@ Hint: For multi-page conversion, use a format string like 'output-%04d.svg'."
             break;
         }
 
-        if (show_help) {
-            stderr.puts (opt_context.get_help (true, null));
-            return 0;
-        }
-
         if (show_version) {
             Reporter.info_puts ("PDF to SVG Converter", VERSION);
             return 0;
@@ -96,7 +86,7 @@ Hint: For multi-page conversion, use a format string like 'output-%04d.svg'."
 
         if (args.length != 3) {
             Reporter.error_puts ("ArgumentError", "Only 2 arguments (input PDF file and output SVG file) are allowed.");
-            stderr.printf ("\n%s", opt_context.get_help (true, null));
+            printerr ("\n%s", opt_context.get_help (true, null));
             return 1; // Argument count error
         }
 

--- a/src/reporter.vala
+++ b/src/reporter.vala
@@ -109,7 +109,7 @@ public class PdfSvgConv.Reporter {
     */
     public static void report_failed_command (string command, int status) {
         if (color_setting.to_bool ()) {
-            stderr.printf ("Command `%s%s%s' failed with status: %s%d%s\n",
+            printerr ("Command `%s%s%s' failed with status: %s%d%s\n",
                 Reporter.EscapeCode.ANSI_BOLD + EscapeCode.ANSI_YELLOW,
                 command,
                 Reporter.EscapeCode.ANSI_RESET,
@@ -118,7 +118,7 @@ public class PdfSvgConv.Reporter {
                 Reporter.EscapeCode.ANSI_RESET);
             return;
         }
-        stderr.printf ("Command `%s' failed with status: %d\n",
+        printerr ("Command `%s' failed with status: %d\n",
             command,
             status);
     }
@@ -133,7 +133,7 @@ public class PdfSvgConv.Reporter {
     */
     public static void report (string color_code, string domain_name, string msg, va_list args) {
         if (color_setting.to_bool ()) {
-            stderr.puts (Reporter.EscapeCode.ANSI_BOLD.concat (
+            printerr ("%s", Reporter.EscapeCode.ANSI_BOLD.concat (
                     color_code,
                     domain_name,
                     Reporter.EscapeCode.ANSI_RESET +
@@ -144,7 +144,7 @@ public class PdfSvgConv.Reporter {
                     "\n"));
             return;
         }
-        stderr.puts (domain_name.concat (": ", msg.vprintf (args), "\n"));
+        printerr ("%s: %s\n", domain_name, msg.vprintf (args));
     }
 
     /*
@@ -156,7 +156,7 @@ public class PdfSvgConv.Reporter {
      */
     public static void report_puts (string color_code, string domain_name, string msg) {
         if (color_setting.to_bool ()) {
-            stderr.puts (Reporter.EscapeCode.ANSI_BOLD.concat (
+            printerr ("%s", Reporter.EscapeCode.ANSI_BOLD.concat (
                     color_code,
                     domain_name,
                     Reporter.EscapeCode.ANSI_RESET +
@@ -167,7 +167,7 @@ public class PdfSvgConv.Reporter {
                     "\n"));
             return;
         }
-        stderr.puts (domain_name.concat (": ", msg, "\n"));
+        printerr ("%s: %s\n", domain_name, msg);
     }
 
     /**
@@ -246,11 +246,11 @@ public class PdfSvgConv.Reporter {
     */
     public static void clear_putserr (string msg, bool show_progress_bar = true) {
         if (show_progress_bar) {
-            stderr.printf ("\r%s\r%s",
+            printerr ("\r%s\r%s",
                 string.nfill (get_console_width (), ' '),
                 msg);
         } else {
-            stderr.puts (msg);
+            printerr ("%s", msg);
         }
     }
 
@@ -326,6 +326,7 @@ public class PdfSvgConv.Reporter {
             print_progress (success_count, failure_count);
             mutex.unlock ();
             return _current_step;
+
         }
 
         /**
@@ -381,7 +382,7 @@ public class PdfSvgConv.Reporter {
             } else {
                 builder.append_printf (": %6.2f%%", percentage);
             }
-            stderr.puts (builder.str);
+            printerr ("%s", builder.str);
         }
     }
 }

--- a/src/svg2pdf.vala
+++ b/src/svg2pdf.vala
@@ -25,7 +25,6 @@ public class PdfSvgConv.Svg2Pdf {
     //static int num_threads = 0;
 
     const OptionEntry[] options = {
-        { "help", 'h', OptionFlags.NONE, OptionArg.NONE, ref show_help, "Show help message", null },
         { "version", 'v', OptionFlags.NONE, OptionArg.NONE, ref show_version, "Display version", null },
         { "color", '\0', OptionFlags.NONE, OptionArg.INT, ref color_level, "Color level of log, 0 for no color, 1 for auto, 2 for always; defaults to 1", "LEVEL" },
         //{ "threads", 'T', OptionFlags.NONE, OptionArg.INT, ref num_threads, "Number of threads to use, 0 for auto; defaults to 0", "NUM" },
@@ -94,10 +93,7 @@ public class PdfSvgConv.Svg2Pdf {
 
     // Main program function
     static int main (string[] original_args) {
-        // Compatibility for Windows and Unix
-        if (Intl.setlocale (LocaleCategory.ALL, ".UTF-8") == null) {
-            Intl.setlocale ();
-        }
+        Intl.setlocale ();
 
 #if WINDOWS
         var args = Win32.get_command_line ();
@@ -116,7 +112,7 @@ public class PdfSvgConv.Svg2Pdf {
             opt_context.parse_strv (ref args);
         } catch (OptionError e) {
             Reporter.error_puts ("OptionError", e.message);
-            stderr.printf ("\n%s", opt_context.get_help (true, null));
+            printerr ("\n%s", opt_context.get_help (true, null));
             return 1; // Argument parsing error
         }
 
@@ -136,11 +132,6 @@ public class PdfSvgConv.Svg2Pdf {
             break;
         }
 
-        if (show_help) {
-            stderr.puts (opt_context.get_help (true, null));
-            return 0;
-        }
-
         if (show_version) {
             Reporter.info_puts ("SVG to PDF Converter", VERSION);
             return 0;
@@ -149,7 +140,7 @@ public class PdfSvgConv.Svg2Pdf {
         // Get the input and output file paths
         if (args.length < 2) {
             Reporter.error_puts ("ArgumentError", "missing input or output file path");
-            stderr.printf ("\n%s", opt_context.get_help (true, null));
+            printerr ("\n%s", opt_context.get_help (true, null));
             return 1; // Missing input or output file path error
         }
 


### PR DESCRIPTION
Replace all direct stderr.printf and stderr.puts calls with printerr for consistent cross-platform error reporting since GLib has fixed charset on Windows